### PR TITLE
fix: handle binary files

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -73,8 +73,8 @@ class Index:
         name = self.EXTENSIONS.get(os.path.splitext(path)[1])
         if name is None:
             interpreter = None
-            with open(path) as f:
-                if f.read(2) == '#!':
+            with open(path, "rb") as f:
+                if f.read(2) == bytearray('#!'.encode('ascii')):
                     interpreter = f.readline().rstrip().rsplit(os.path.sep)[-1]
             name = self.INTERPRETERS.get(interpreter)
         return self.__languages.get(name)


### PR DESCRIPTION
While checking for an interpreter, assume a file can be non-UTF8.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
