### PR TITLE
Check entire file for SPDX identifier

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -26,8 +26,6 @@ class Language:
         with open(path) as f:
             while f:
                 line = f.readline()
-                if self.__shebang and line.startswith('#!'):
-                    line = f.readline()
 
                 for matcher in self.__match:
                     match = matcher.match(line)

--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -24,14 +24,15 @@ class Language:
     def license(self, path):
         "Find the license from the SPDX header."
         with open(path) as f:
-            line = f.readline()
-            if self.__shebang and line.startswith('#!'):
+            while f:
                 line = f.readline()
+                if self.__shebang and line.startswith('#!'):
+                    line = f.readline()
 
-        for matcher in self.__match:
-            match = matcher.match(line)
-            if match:
-                return match.group(1)
+                for matcher in self.__match:
+                    match = matcher.match(line)
+                    if match:
+                        return match.group(1)
 
         return None
 


### PR DESCRIPTION
With this slight change, the entire files are checked for SPDX identifiers. This resolves the issue, that the id is not found, when e.g. a copyright notice comes before the id.

- Resolves enarx/spdx#12