### PR TITLE
Fix infinite while loop

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -24,9 +24,8 @@ class Language:
     def license(self, path):
         "Find the license from the SPDX header."
         with open(path) as f:
-            while f:
-                line = f.readline()
-
+            lines = f.readlines()
+            for line in lines:
                 for matcher in self.__match:
                     match = matcher.match(line)
                     if match:


### PR DESCRIPTION
Following up on PR #13, replacing PR #16:

As now all lines in a file are checked, the while loop going through all lines per file does not end if no identifier is found. This PR fixes the issue by iterating over all lines with a for loop and breaking out of the function afterwards.