### PR TITLE
Ignore symlinks in the tree walk

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -98,6 +98,10 @@ class Index:
             for file in files:
                 path = os.path.join(root, file)
 
+                # If the file is a symlink, don't bother
+                if os.path.islink( path ):
+                    continue
+
                 # Find the language of the file.
                 language = self.language(path)
                 if language is None:


### PR DESCRIPTION
Trying to open a symlink directly doesn't go well, and may reference things outside the repository.  Assuming that a symlink doesn't need to be independently opened and checked as if the file is in the repository it'll get picked up elsewhere, and this would just be a dupe, or if it's external it's not part of the repository and not entirely useful to check anyway.

If it's a symlink, just skip it.