### PR TITLE
fix: Update verify-spdx-headers to ignore empty files.

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -100,11 +100,14 @@ class Index:
 
             for file in files:
                 path = os.path.join(root, file)
+                
+                # If the file is empty skip. 
+                if os.path.getsize(path) == 0:
+                    continue
 
                 # If the file is a symlink, don't bother
                 if os.path.islink( path ):
                     continue
-
                 # Find the language of the file.
                 language = self.language(path)
                 if language is None:


### PR DESCRIPTION
fix: Adding a check for empty files and skipping. This is primarily to get around empty __init__.py files. 

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
