### PR TITLE
fix: allow whitespace character in license SLUG

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -4,7 +4,7 @@
 import os
 import re
 
-SLUG = re.compile('[a-zA-Z0-9.-]+')
+SLUG = re.compile('[- a-zA-Z0-9.]+')
 SPDX = re.compile(f'SPDX-License-Identifier:\s+({SLUG.pattern})')
 
 class Language:


### PR DESCRIPTION
This PR fixes the regex for the license SLUG by (1) allowing the space character to occur and (2) moving the `-` to the beginning of the list of allowed characters where it belongs.
