### PR TITLE
feat: add language definition for `tablegen`

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -59,6 +59,7 @@ class Index:
         '.hpp': 'c++',
         '.cc': 'c++',
         '.hh': 'c++',
+        '.td': 'tablegen',
         '.ts': 'typescript',
         '.sh': 'shell',
     }
@@ -71,6 +72,7 @@ class Index:
             'c++': Language('//+', ('/\\*', '\\*/')),
             'rust': Language('//+', '//!', ('/\\*', '\\*/')),
             'protobuf': Language('//+', '//!', ('/\\*', '\\*/')),
+            'tablegen': Language('//+'),
             'typescript': Language('//+', ('/\\*', '\\*/'), shebang=True),
             'shell': Language('#+', shebang=True),
         }


### PR DESCRIPTION
This language is used by LLVM and MLIR for declaratively defining their IR (see [documentation](https://llvm.org/docs/TableGen/index.html)).

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
