### PR TITLE
Update README.md to use licenses separated by new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ jobs:
       uses: actions/checkout@v2
     - uses: enarx/spdx@master
       with:
-        licenses: Apache-2.0 MIT
+        licenses: |-
+          Apache-2.0
+          MIT
 ```
 
 ## How it Works


### PR DESCRIPTION
[8dd1a10](https://github.com/enarx/spdx/commit/8dd1a10623686920a56406bbacb795c61fa23343) changes license listing format to be separated by new lines. The example in readme should follow same format. 