### PR TITLE
feat: support multi-line c-style comments

### DIFF
--- a/verify-spdx-headers
+++ b/verify-spdx-headers
@@ -70,13 +70,13 @@ class Index:
         self.__languages = {
             'python': Language('#+', shebang=True),
             'ruby': Language('#+', shebang=True),
-            'c': Language('//+', ('/\\*', '\\*/')),
-            'c++': Language('//+', ('/\\*', '\\*/')),
-            'cuda-c': Language('//+', ('/\\*', '\\*/')),
-            'rust': Language('//+', '//!', ('/\\*', '\\*/')),
-            'protobuf': Language('//+', '//!', ('/\\*', '\\*/')),
+            'c': Language('//+', ('[ /]\\*', '\\*?/?')),
+            'c++': Language('//+', ('[ /]\\*', '\\*?/?')),
+            'cuda-c': Language('//+', ('[ /]\\*', '\\*?/?')),
+            'rust': Language('//+', '//!', ('[ /]\\*', '\\*?/?')),
+            'protobuf': Language('//+', '//!', ('[ /]\\*', '\\*?/?')),
             'tablegen': Language('//+'),
-            'typescript': Language('//+', ('/\\*', '\\*/'), shebang=True),
+            'typescript': Language('//+', ('[ /]\\*', '\\*?/?'), shebang=True),
             'shell': Language('#+', shebang=True),
         }
 


### PR DESCRIPTION
Support multi-line C-style comments with minimal, non-grouping regexes that fit with the existing program flow.

This change will allow the existing tool to also match e.g.

```cpp
/*
 * Copyright (c) 2025 Somebody
 *
 * SPDX-License-Identifier: Apache-2.0
 */
```

or

```cpp
/*
 * Copyright (c) 2025 Somebody
 * SPDX-License-Identifier: Apache-2.0
 */
```

Some projects do not allow the use of c99 / c++ style comments and use exclusively c-style multi-line comments for Copyright and SPDX license identifier.